### PR TITLE
Remove CanBeForked from header template

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -49,10 +49,10 @@
 						{{.NumStars}}
 					</a>
 				</div>
-				{{if .CanBeForked}}
-					<div class="ui compact labeled button" tabindex="0">
-						<a class="ui compact button {{if not $.CanSignedUserFork}}poping up{{end}}" {{if $.CanSignedUserFork}}href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{else}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" data-position="top center" data-variation="tiny"{{end}}>
-							<i class="octicon octicon-repo-forked"></i>{{$.i18n.Tr "repo.fork"}}
+				{{if and (not .IsEmpty) ($.Permission.CanRead $.UnitTypeCode)}}
+					<div class="ui labeled button {{if and ($.IsSigned) (not $.CanSignedUserFork)}}disabled-repo-button{{end}}" tabindex="0">
+						<a class="ui compact basic button {{if or (not $.IsSigned) (not $.CanSignedUserFork)}}poping up{{end}}" {{if $.CanSignedUserFork}}href="{{AppSubUrl}}/repo/fork/{{.ID}}"{{else if $.IsSigned}} data-content="{{$.i18n.Tr "repo.fork_from_self"}}" {{ else }} data-content="{{$.i18n.Tr "repo.fork_guest_user" }}" rel="nofollow" href="{{AppSubUrl}}/user/login?redirect_to={{AppSubUrl}}/repo/fork/{{.ID}}" {{end}} data-position="top center" data-variation="tiny">
+							{{svg "octicon-repo-forked" 16}}{{$.i18n.Tr "repo.fork"}}
 						</a>
 						<a class="ui basic label" href="{{.Link}}/forks">
 							{{.NumForks}}


### PR DESCRIPTION
Value `CanBeForked` is no longer available, so grab the forking snippet from https://github.com/go-gitea/gitea/blob/0e24af6951fa65d5094ab6da0f182697aab2a6f0/templates/repo/header.tmpl#L60-L69