### PR TITLE
Fix comment menu in issues

### DIFF
--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -63,6 +63,7 @@
 	<link rel="alternate icon" href="{{StaticUrlPrefix}}/img/favicon.png" type="image/png">
 	<link rel="mask-icon" href="{{StaticUrlPrefix}}/img/gitea-safari.svg" color="#609926">
 	<link rel="fluid-icon" href="{{StaticUrlPrefix}}/img/gitea-lg.png" title="{{AppName}}">
+	<link rel="stylesheet" href="/vendor/assets/font-awesome/css/font-awesome.min.css">
 {{if .RequireSimpleMDE}}
 	<link rel="stylesheet" href="{{StaticUrlPrefix}}/vendor/plugins/simplemde/simplemde.min.css">
 {{end}}


### PR DESCRIPTION
Include font-awesome icons so the comment menu appears, allowing editing, etc.

Currently deployed to content-qa for review. You must be logged in (and maybe even own the comment) to see the menu.