### PR TITLE
Localization strings for version compatibility

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -777,6 +777,17 @@ migrate.git.description = Migrating or Mirroring git data from Git services
 migrate.gitlab.description = Migrating data from GitLab.com or Self-Hosted gitlab server.
 migrate.gitea.description = Migrating data from Gitea.com or Self-Hosted Gitea server.
 
+migrate_type = Migration Type
+migrate_type_helper = This repository will be a <span class="text blue">mirror</span>
+migrate_repo = Migrate Repository
+migrate.clone_address = Clone Address
+migrate.clone_address_desc = This can be a HTTP/HTTPS/GIT URL
+migrate.clone_local_path = or local server path
+migrate.permission_denied = You are not allowed to import local repositories.
+migrate.invalid_local_path = "Invalid local path; it does not exist or is not a directory."
+migrate.failed = Migration failed: %v
+migrate.lfs_mirror_unsupported = Mirroring LFS objects is not supported - use 'git lfs fetch --all' and 'git lfs push --all' instead.
+
 mirror_from = mirror of
 forked_from = forked from
 generated_from = generated from


### PR DESCRIPTION
Fix missing translation text for new mirrors.

This fix is deployed to https://content-qa.bibletranslationtools.org/repo/migrate for review.